### PR TITLE
Muessli/test case 3 nodes

### DIFF
--- a/src/run_test_case.py
+++ b/src/run_test_case.py
@@ -304,7 +304,7 @@ class TestCase:
 
 ##### Example of use ######
 system_folder = "./tests/muessli/case_3_nodes/" #You can keep this path
-data_folder = "../muessli_cases/case_3_nodes/timeseries" #This path has to be changed depending on where you saved the timeseries folder.
+data_folder = "../../3_MuESSLi/Génération données/case_3_nodes/case_3_nodes/timeseries" #This path has to be changed depending on where you saved the timeseries folder.
 #For instance, the path to credits_fr.txt file is data_folder+"/credits_fr.txt"
 case = TestCase(system_folder, data_folder)
 T,W = 5, 52

--- a/tests/muessli/case_3_nodes/library.yml
+++ b/tests/muessli/case_3_nodes/library.yml
@@ -55,19 +55,27 @@ library:
 
     - id: link
       parameters:
-        - id: capacity_direct
-          time-dependent: true
-          scenario-dependent: true
-        - id: capacity_indirect
-          time-dependent: true
-          scenario-dependent: true
+        - id: capacity_direct_nominal
+          time-dependent: false
+          scenario-dependent: false
+        - id: capacity_indirect_nominal
+          time-dependent: false
+          scenario-dependent: false
       variables:
         - id: flow_direct
           lower-bound: 0
-          upper-bound: capacity_direct
+        - id: capacity_direct
+          time-dependent: false
+          scenario-dependent: false
+          lower-bound: 0
+          upper-bound: capacity_direct_nominal
         - id: flow_indirect
           lower-bound: 0
-          upper-bound: capacity_indirect
+        - id: capacity_indirect
+          time-dependent: false
+          scenario-dependent: false
+          lower-bound: 0
+          upper-bound: capacity_indirect_nominal
         - id: flow
       ports:
         - id: out_port
@@ -82,6 +90,10 @@ library:
           field: flow
           definition: -flow
       constraints:
+        - id: upper_bound_direct_flow
+          expression: flow_direct <= capacity_direct
+        - id: upper_bound_indirect_flow
+          expression: flow_indirect <= capacity_indirect
         - id: flow_direct_indirect
           expression: flow = flow_direct - flow_indirect
 

--- a/tests/muessli/case_3_nodes/system.yml
+++ b/tests/muessli/case_3_nodes/system.yml
@@ -473,33 +473,33 @@ system:
     - id: ch_de_link
       model: muessli-lib.link
       parameters:
-      - id: capacity_direct
+      - id: capacity_direct_nominal
         scenario-dependent: false
         time-dependent: false
         value: 4000
-      - id: capacity_indirect
+      - id: capacity_indirect_nominal
         scenario-dependent: false
         time-dependent: false
         value: 1700
     - id: ch_fr_link
       model: muessli-lib.link
       parameters:
-      - id: capacity_direct
+      - id: capacity_direct_nominal
         scenario-dependent: false
         time-dependent: false
         value: 1300
-      - id: capacity_indirect
+      - id: capacity_indirect_nominal
         scenario-dependent: false
         time-dependent: false
         value: 2800
     - id: de_fr_link
       model: muessli-lib.link
       parameters:
-      - id: capacity_direct
+      - id: capacity_direct_nominal
         scenario-dependent: false
         time-dependent: false
         value: 3300
-      - id: capacity_indirect
+      - id: capacity_indirect_nominal
         scenario-dependent: false
         time-dependent: false
         value: 3300


### PR DESCRIPTION

vary the generators and links capacity parameters (potential investment decisions, denoted by x in my previous email).

The run_test_case.py file has been adapted, but the previous syntax is still valid (I've added ‘optional’ arguments to the simulation function). In principle, you don't need to change the way you call this function when you don’t want to modify these capacities. I’ve also provided an example of code to the “simulation” function where the capacities are changed.
The files “library.yml” and “system.yml” have been slightly modified, so you just have to update those files from GitHub (but the data is the same).